### PR TITLE
Update benchmark run loop to await benchmark sequentially

### DIFF
--- a/benchmark.ts
+++ b/benchmark.ts
@@ -190,7 +190,9 @@ const testRuns = 1
 // Run
 // ===================================
 console.clear()
-for (let i = 0; i < testRuns; i++) {
-	console.log(`Starting benchmark run ${i + 1}/${testRuns}`)
-	runBenchmark(tests, model, baseUrl)
-}
+;(async () => {
+        for (let i = 0; i < testRuns; i++) {
+                console.log(`Starting benchmark run ${i + 1}/${testRuns}`)
+                await runBenchmark(tests, model, baseUrl)
+        }
+})()


### PR DESCRIPTION
## Summary
- wrap benchmark run loop in async IIFE
- await `runBenchmark` calls for sequential execution

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module '@langchain/ollama')*

------
https://chatgpt.com/codex/tasks/task_e_6864cbff85f0832cb7ac226f07b1d7f6